### PR TITLE
Change CURRENT_VERSION to 1 so the rawtransaction interface works

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -529,7 +529,7 @@ class CTransaction
 public:
     static int64 nMinTxFee;
     static int64 nMinRelayTxFee;
-    static const int CURRENT_VERSION=3;
+    static const int CURRENT_VERSION=1;
     int nVersion;
     std::vector<CTxIn> vin;
     std::vector<CTxOut> vout;
@@ -1415,7 +1415,7 @@ class CBlockHeader
 {
 public:
     // header
-    static const int CURRENT_VERSION=3;
+    static const int CURRENT_VERSION=1;
     int nVersion;
     uint256 hashPrevBlock;
     uint256 hashMerkleRoot;


### PR DESCRIPTION
CURRENT_VERSION set at 3 causes the raw interface to produce transaction hex that will not confirm (make it into blocks).  The transactions simply sit in the mempool and are never picked up or rejected.  getrawtransaction on any txid and you'll see the version byte is 1.