### PR TITLE
rpcrawtransaction.o error due to boost incompatible version

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -240,7 +240,7 @@ Value listunspent(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(pk, address))
             {
-                const CScriptID& hash = boost::get<const CScriptID&>(address);
+                const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));


### PR DESCRIPTION
Compiling potcoin-qt on Debian 
-----> 
makefile.unix:190: recipe for target 'obj/rpcrawtransaction.o' failed make: *** [obj/rpcrawtransaction.o] Error 1

-----> Fix <-----

rpcrawtransaction.cpp check line 242 ==>

#Before
const CScriptID& hash = boost::get<const CScriptID&>(address);
#After
const CScriptID& hash = boost::get<CScriptID>(address);

Source: litecoin-project/litecoin#243